### PR TITLE
chore: apply publint and plan V1

### DIFF
--- a/.changeset/many-birds-cry.md
+++ b/.changeset/many-birds-cry.md
@@ -1,0 +1,5 @@
+---
+"dotsecret": patch
+---
+
+Add fixes from publint

--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,8 @@ node_modules/
 .pnp.js
 
 # Local env files
-.env
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*
+!.env.example
 
 # Build Outputs
 .vercel/
@@ -32,3 +29,7 @@ pnpm-debug.log*
 # Misc
 .DS_Store
 *.pem
+
+# dotsecret
+.secret*
+!.secret.config

--- a/packages/cli/.npmignore
+++ b/packages/cli/.npmignore
@@ -1,0 +1,8 @@
+.turbo/
+src/
+.eslintignore
+.eslintrc.cjs
+CHANGELOG.md
+reset.d.ts
+tsconfig.json
+tsup.config.ts

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,14 +11,15 @@
   },
   "license": "MIT",
   "author": "arsnl",
+  "type": "commonjs",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/index.mjs"
     }
   },
   "bin": {

--- a/v1.md
+++ b/v1.md
@@ -1,0 +1,39 @@
+# dotsecret - V1
+
+There is the description of the project commands, files and secrets managers that dotsecret is planned to support in the V1.
+
+## Commands
+
+- **init**: Initialize project
+- **login**: Log in
+- **logout**: Log out
+- **whoami**: Display the current logged in user
+- **renew**: Renew the current session
+- **open**: Open secrets manager page
+- **pull**: Pull .secret securely
+- **push**: Push .secret securely
+- **versions**: List version history
+- **diff**: Show differences between versions
+- **render**: Render the .secret template files
+- **audit**: Audit the project
+- **fix**: Fix audit issues if possible
+- **help**: Display help for dotsecret
+
+## Files
+
+- **.secret.local**: [.gitignore] Contains the secrets pulled from the secrets manager that can be edited and pushed back
+- **.secret.previous**: [.gitignore] Contains the previous version of the .secret.local before a pull
+- **.secret.config**: Contains the configuration for the project
+- **.secret.me**: [.gitignore] Contains the user credentials to connect to the secrets manager
+- **\*.secret**: Template files that can be rendered with dotsecret render (eg: config.json.secret -> config.json)
+- **Rendered files**: [.gitignore] The rendered files from the \*.secret files (eg: config.json, rendered from config.json.secret)
+
+## Secrets Managers
+
+- **HashiCorp Vault**: https://www.vaultproject.io/
+- **Doppler**: [TBD] https://www.doppler.com/
+- **Infisical**: [TBD] https://infisical.com/
+- **AWS Secrets Manager**: [TBD] https://aws.amazon.com/secrets-manager/
+- **Azure Key Vault**: [TBD] https://azure.microsoft.com/en-us/products/key-vault
+- **Google Cloud Secret Manager**: [TBD] https://cloud.google.com/security/products/secret-manager
+- **Vercel Project Environment Variables**: [TBD] https://vercel.com/docs/projects/environment-variables


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `.gitignore` to better handle local environment and secret files.
	- Improved npm package by refining `.npmignore` content.

- **Documentation**
	- Added detailed documentation for `dotsecret` version 1, including commands, key files, and supported secrets managers.

- **Bug Fixes**
	- Patched issues related to `dotsecret` with fixes from `publint`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->