### PR TITLE
fix: remove "type": "commonjs"

### DIFF
--- a/.changeset/plenty-games-know.md
+++ b/.changeset/plenty-games-know.md
@@ -1,0 +1,5 @@
+---
+"dotsecret": patch
+---
+
+Add LICENSE file

--- a/.changeset/strong-hats-know.md
+++ b/.changeset/strong-hats-know.md
@@ -1,0 +1,5 @@
+---
+"dotsecret": patch
+---
+
+Remove the "type": "commonjs" in the package.json

--- a/packages/cli/.npmignore
+++ b/packages/cli/.npmignore
@@ -1,9 +1,5 @@
-.turbo/
-node_modules/
-src/
-.eslintignore
-.eslintrc.cjs
-CHANGELOG.md
-reset.d.ts
-tsconfig.json
-tsup.config.ts
+*
+!dist/**/*
+!package.json
+!README.md
+

--- a/packages/cli/.npmignore
+++ b/packages/cli/.npmignore
@@ -2,4 +2,4 @@
 !dist/**/*
 !package.json
 !README.md
-
+!LICENSE

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Mark Arseneault
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,6 @@
   },
   "license": "MIT",
   "author": "arsnl",
-  "type": "commonjs",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Remove the "type": "commonjs" to try avoid NPM to include the node_modules folder of the EMS only packages in the published package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the package configuration to enhance compatibility and streamline the package publishing process.
	- Refined the ignore patterns for CLI package to optimize package size and content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->