### PR TITLE
chore: remove esm from build to reduce pkg size

### DIFF
--- a/.changeset/violet-apes-obey.md
+++ b/.changeset/violet-apes-obey.md
@@ -1,0 +1,5 @@
+---
+"dotsecret": patch
+---
+
+Build CJS only

--- a/.prettierignore
+++ b/.prettierignore
@@ -23,6 +23,11 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 
+# Lock files
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+
 # Misc
 .DS_Store
 *.pem

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -14,13 +14,13 @@
     "incremental": true,
     "plugins": [
       {
-        "name": "next",
-      },
+        "name": "next"
+      }
     ],
     "paths": {
-      "@/*": ["./src/*"],
-    },
+      "@/*": ["./src/*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules"]
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dotsecret",
-  "version": "0.0.0-next.6",
+  "version": "0.0.0-next.5",
   "description": "Create and share secret files seamlessly across devices, platforms, and team members",
   "homepage": "https://dotsecret.org/",
   "bugs": {
@@ -11,15 +11,11 @@
   },
   "license": "MIT",
   "author": "arsnl",
+  "type": "commonjs",
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
-      },
       "require": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -14,9 +14,9 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"],
-      "@pkg": ["./package.json"],
-    },
+      "@pkg": ["./package.json"]
+    }
   },
   "include": ["**/*.ts"],
-  "exclude": ["node_modules", "**/*.test.ts", "dist"],
+  "exclude": ["node_modules", "**/*.test.ts", "dist"]
 }

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -3,12 +3,12 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   name: "dotsecret",
-  target: "node18",
+  target: "node16",
   entry: ["src/index.ts", "src/cli.ts"],
   outDir: "dist",
   dts: true,
   sourcemap: false,
-  format: ["cjs", "esm"],
+  format: "cjs",
   clean: true,
   // We need to include theses packages in the bundle since they are ESM only and need to be converted to CJS.
   noExternal: [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the code formatting configuration to ignore lock files.
- **Refactor**
	- Adjusted the build configuration to target Node.js version 16 and refine the output format to CommonJS (CJS) only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->