### PR TITLE
chore: move esm only packages to bridge files

### DIFF
--- a/.changeset/odd-humans-occur.md
+++ b/.changeset/odd-humans-occur.md
@@ -1,0 +1,5 @@
+---
+"dotsecret": patch
+---
+
+Move ESM only packages into bridge files

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ build/
 dist/
 .astro/
 .cache/
+tsconfig.tsbuildinfo
 
 # Logs
 npm-debug.log*

--- a/packages/cli/.eslintrc.cjs
+++ b/packages/cli/.eslintrc.cjs
@@ -3,4 +3,41 @@ module.exports = {
   root: true,
   extends: ["peppy"],
   parserOptions: { tsconfigRootDir: __dirname, project: "./tsconfig.json" },
+  rules: {
+    "no-restricted-imports": [
+      "error",
+      {
+        name: "boxen",
+        message: "Please use @/esm-only/boxen instead.",
+      },
+      {
+        name: "chalk",
+        message: "Please use @/esm-only/chalk instead.",
+      },
+      {
+        name: "color-json",
+        message: "Please use @/esm-only/color-json instead.",
+      },
+      {
+        name: "execa",
+        message: "Please use @/esm-only/execa instead.",
+      },
+      {
+        name: "find-up",
+        message: "Please use @/esm-only/find-up instead.",
+      },
+      {
+        name: "globby",
+        message: "Please use @/esm-only/globby instead.",
+      },
+      {
+        name: "multimatch",
+        message: "Please use @/esm-only/multimatch instead.",
+      },
+      {
+        name: "ora",
+        message: "Please use @/esm-only/ora instead.",
+      },
+    ],
+  },
 };

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -68,15 +68,5 @@
     "tsup": "8.0.2",
     "typescript": "5.3.3",
     "yalc": "1.0.0-pre.53"
-  },
-  "bundledDependencies": [
-    "boxen",
-    "chalk",
-    "color-json",
-    "execa",
-    "find-up",
-    "globby",
-    "multimatch",
-    "ora"
-  ]
+  }
 }

--- a/packages/cli/src/commands/audit/fix.ts
+++ b/packages/cli/src/commands/audit/fix.ts
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import chalk from "@/esm-only/chalk";
 import { runAudit } from "@/services/audit";
 import { getCommand } from "@/services/command";
 import { getLogger } from "@/services/logger";

--- a/packages/cli/src/commands/config/default.ts
+++ b/packages/cli/src/commands/config/default.ts
@@ -1,4 +1,4 @@
-import colorJson from "color-json";
+import colorJson from "@/esm-only/color-json";
 import { getCommand } from "@/services/command";
 import { getDefaultConfig } from "@/services/config";
 import { getLogger } from "@/services/logger";

--- a/packages/cli/src/commands/config/show.ts
+++ b/packages/cli/src/commands/config/show.ts
@@ -1,4 +1,4 @@
-import colorJson from "color-json";
+import colorJson from "@/esm-only/color-json";
 import { getCommand } from "@/services/command";
 import { getConfig } from "@/services/config";
 import { getLogger } from "@/services/logger";

--- a/packages/cli/src/commands/projects/delete.ts
+++ b/packages/cli/src/commands/projects/delete.ts
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import chalk from "@/esm-only/chalk";
 import { getCommand } from "@/services/command";
 import { getConfig } from "@/services/config";
 import { getLogger } from "@/services/logger";

--- a/packages/cli/src/commands/projects/list.ts
+++ b/packages/cli/src/commands/projects/list.ts
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import chalk from "@/esm-only/chalk";
 import { getCommand } from "@/services/command";
 import { getLogger } from "@/services/logger";
 import { getStore } from "@/services/store";

--- a/packages/cli/src/commands/secrets/index.ts
+++ b/packages/cli/src/commands/secrets/index.ts
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import chalk from "@/esm-only/chalk";
 import { getCommand } from "@/services/command";
 import { getShowCommand } from "./show";
 

--- a/packages/cli/src/commands/secrets/show.ts
+++ b/packages/cli/src/commands/secrets/show.ts
@@ -1,5 +1,5 @@
-import chalk from "chalk";
-import colorJson from "color-json";
+import chalk from "@/esm-only/chalk";
+import colorJson from "@/esm-only/color-json";
 import {
   argumentSecrets,
   type ParsedArgumentSecrets,

--- a/packages/cli/src/commands/store/delete.ts
+++ b/packages/cli/src/commands/store/delete.ts
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import chalk from "@/esm-only/chalk";
 import { getCommand } from "@/services/command";
 import { getLogger } from "@/services/logger";
 import { confirmOrAbort } from "@/services/prompt";

--- a/packages/cli/src/commands/store/reset.ts
+++ b/packages/cli/src/commands/store/reset.ts
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import chalk from "@/esm-only/chalk";
 import { getCommand } from "@/services/command";
 import { getLogger } from "@/services/logger";
 import { confirmOrAbort } from "@/services/prompt";

--- a/packages/cli/src/commands/store/show.ts
+++ b/packages/cli/src/commands/store/show.ts
@@ -1,5 +1,5 @@
-import chalk from "chalk";
-import colorJson from "color-json";
+import chalk from "@/esm-only/chalk";
+import colorJson from "@/esm-only/color-json";
 import { getCommand } from "@/services/command";
 import { getLogger } from "@/services/logger";
 import { getStore } from "@/services/store";

--- a/packages/cli/src/commands/templates/delete.ts
+++ b/packages/cli/src/commands/templates/delete.ts
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import chalk from "@/esm-only/chalk";
 import {
   argumentTemplates,
   type ParsedArgumentTemplates,

--- a/packages/cli/src/commands/templates/index.ts
+++ b/packages/cli/src/commands/templates/index.ts
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import chalk from "@/esm-only/chalk";
 import { getCommand } from "@/services/command";
 import { getDeleteCommand } from "./delete";
 import { getListCommand } from "./list";

--- a/packages/cli/src/commands/templates/list.ts
+++ b/packages/cli/src/commands/templates/list.ts
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import chalk from "@/esm-only/chalk";
 import {
   argumentTemplates,
   type ParsedArgumentTemplates,

--- a/packages/cli/src/commands/templates/write.ts
+++ b/packages/cli/src/commands/templates/write.ts
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import chalk from "@/esm-only/chalk";
 import {
   argumentTemplates,
   type ParsedArgumentTemplates,

--- a/packages/cli/src/commands/tokens/delete.ts
+++ b/packages/cli/src/commands/tokens/delete.ts
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import chalk from "@/esm-only/chalk";
 import {
   argumentTokensName,
   type ParsedArgumentTokensName,

--- a/packages/cli/src/commands/tokens/list.ts
+++ b/packages/cli/src/commands/tokens/list.ts
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import chalk from "@/esm-only/chalk";
 import { getCommand } from "@/services/command";
 import { getLogger } from "@/services/logger";
 import { getTokens } from "@/services/token";

--- a/packages/cli/src/commands/tokens/lookup.ts
+++ b/packages/cli/src/commands/tokens/lookup.ts
@@ -1,5 +1,5 @@
-import chalk from "chalk";
-import colorJson from "color-json";
+import chalk from "@/esm-only/chalk";
+import colorJson from "@/esm-only/color-json";
 import {
   argumentTokensName,
   type ParsedArgumentTokensName,

--- a/packages/cli/src/commands/tokens/renew.ts
+++ b/packages/cli/src/commands/tokens/renew.ts
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import chalk from "@/esm-only/chalk";
 import {
   argumentTokensName,
   type ParsedArgumentTokensName,

--- a/packages/cli/src/commands/tokens/save.ts
+++ b/packages/cli/src/commands/tokens/save.ts
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import chalk from "@/esm-only/chalk";
 import {
   argumentTokensNameId,
   type ParsedArgumentTokensNameId,

--- a/packages/cli/src/esm-only/.eslintrc.cjs
+++ b/packages/cli/src/esm-only/.eslintrc.cjs
@@ -1,0 +1,7 @@
+/** @type {import("eslint").Linter.Config} */
+module.exports = {
+  rules: {
+    "import/no-extraneous-dependencies": ["off"],
+    "no-restricted-imports": ["off"],
+  },
+};

--- a/packages/cli/src/esm-only/boxen.ts
+++ b/packages/cli/src/esm-only/boxen.ts
@@ -1,0 +1,4 @@
+import boxen from "boxen";
+
+export * from "boxen";
+export default boxen;

--- a/packages/cli/src/esm-only/chalk.ts
+++ b/packages/cli/src/esm-only/chalk.ts
@@ -1,0 +1,4 @@
+import chalk from "chalk";
+
+export * from "chalk";
+export default chalk;

--- a/packages/cli/src/esm-only/color-json.ts
+++ b/packages/cli/src/esm-only/color-json.ts
@@ -1,0 +1,4 @@
+import colorJson from "color-json";
+
+export * from "color-json";
+export default colorJson;

--- a/packages/cli/src/esm-only/execa.ts
+++ b/packages/cli/src/esm-only/execa.ts
@@ -1,0 +1,4 @@
+import * as execa from "execa";
+
+export * from "execa";
+export default execa;

--- a/packages/cli/src/esm-only/find-up.ts
+++ b/packages/cli/src/esm-only/find-up.ts
@@ -1,0 +1,4 @@
+import * as findUp from "find-up";
+
+export * from "find-up";
+export default findUp;

--- a/packages/cli/src/esm-only/globby.ts
+++ b/packages/cli/src/esm-only/globby.ts
@@ -1,0 +1,4 @@
+import * as globby from "globby";
+
+export * from "globby";
+export default globby;

--- a/packages/cli/src/esm-only/multimatch.ts
+++ b/packages/cli/src/esm-only/multimatch.ts
@@ -1,0 +1,4 @@
+import multimatch from "multimatch";
+
+export * from "multimatch";
+export default multimatch;

--- a/packages/cli/src/esm-only/ora.ts
+++ b/packages/cli/src/esm-only/ora.ts
@@ -1,0 +1,4 @@
+import ora from "ora";
+
+export * from "ora";
+export default ora;

--- a/packages/cli/src/services/command.ts
+++ b/packages/cli/src/services/command.ts
@@ -1,7 +1,7 @@
 import pkg from "@pkg";
-import boxen from "boxen";
-import chalk from "chalk";
 import { Command } from "commander";
+import boxen from "@/esm-only/boxen";
+import chalk from "@/esm-only/chalk";
 import {
   optionConfig,
   optionCwd,

--- a/packages/cli/src/services/config.ts
+++ b/packages/cli/src/services/config.ts
@@ -1,8 +1,8 @@
 import { cosmiconfig } from "cosmiconfig";
-import { findUp } from "find-up";
 import { chain } from "lodash";
 import nodePath from "node:path";
 import { z } from "zod";
+import { findUp } from "@/esm-only/find-up";
 import { type CommandOptions } from "@/services/command";
 import { getIssuesCollector } from "@/services/issue";
 

--- a/packages/cli/src/services/issue.ts
+++ b/packages/cli/src/services/issue.ts
@@ -1,9 +1,9 @@
 import pkg from "@pkg";
-import chalk from "chalk";
 import stringify from "fast-json-stable-stringify";
 import nodeCrypto from "node:crypto";
 import { getBorderCharacters, table } from "table";
 import { z } from "zod";
+import chalk from "@/esm-only/chalk";
 import { getLogger } from "@/services/logger";
 
 export const SCOPES = [

--- a/packages/cli/src/services/prompt.ts
+++ b/packages/cli/src/services/prompt.ts
@@ -1,6 +1,6 @@
-import boxen from "boxen";
-import chalk from "chalk";
 import _prompts from "prompts";
+import boxen from "@/esm-only/boxen";
+import chalk from "@/esm-only/chalk";
 import { getLogger } from "@/services/logger";
 
 const handlePromptCancel = () => {

--- a/packages/cli/src/services/template.ts
+++ b/packages/cli/src/services/template.ts
@@ -1,8 +1,8 @@
-import { globby } from "globby";
-import multimatch from "multimatch";
 import nodeFs from "node:fs";
 import nodePath from "node:path";
 import nunjucks from "nunjucks";
+import { globby } from "@/esm-only/globby";
+import multimatch from "@/esm-only/multimatch";
 import { type CommandOptions } from "@/services/command";
 import { getConfig } from "@/services/config";
 import {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,8 +1,8 @@
-import { execa } from "execa";
 import stringify from "fast-json-stable-stringify";
 import yaml from "js-yaml";
 import nodeFs from "node:fs";
 import nodePath from "node:path";
+import { execa } from "@/esm-only/execa";
 
 export function memoize<T extends (...args: any[]) => any>(fn: T) {
   const cache: Record<string, any> = {};

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   format: "cjs",
   clean: true,
   // We need to include theses packages in the bundle since they are ESM only and need to be converted to CJS.
+  // Every package here need to have a bridge file in src/esm-only and a new eslint entry for the no-restricted-imports rule.
   noExternal: [
     "boxen",
     "chalk",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `.gitignore` to ignore additional build information files.
- **New Features**
	- Added new ESM-only module support files for various libraries (`chalk`, `color-json`, `boxen`, etc.), enhancing compatibility and customization.
- **Refactor**
	- Updated import paths across various CLI commands and services to utilize specific ESM-only paths, improving module resolution and project structure.
	- Introduced ESLint configuration adjustments for ESM-only modules and updated the build configuration to include new requirements for bridge files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->